### PR TITLE
TEST srb2: init at 2.2.8

### DIFF
--- a/pkgs/games/srb2/default.nix
+++ b/pkgs/games/srb2/default.nix
@@ -1,0 +1,90 @@
+{ lib
+, stdenv
+, fetchurl
+, fetchFromGitHub
+, substituteAll
+, cmake
+, curl
+, nasm
+, openmpt123
+, p7zip
+, libgme
+, libpng
+, SDL2
+, SDL2_mixer
+, zlib
+}:
+
+let
+
+assets_version = "2.2.5";
+
+assets = fetchurl {
+  url = "https://github.com/mazmazz/SRB2/releases/download/SRB2_assets_220/srb2-${assets_version}-assets.7z";
+  sha256 = "1m9xf3vraq9nipsi09cyvvfa4i37gzfxg970rnqfswd86z9v6v00";
+};
+
+assets_optional = fetchurl {
+  url = "https://github.com/mazmazz/SRB2/releases/download/SRB2_assets_220/srb2-${assets_version}-optional-assets.7z";
+  sha256 = "1j29jrd0r1k2bb11wyyl6yv9b90s2i6jhrslnh77qkrhrwnwcdz4";
+};
+
+in stdenv.mkDerivation rec {
+  pname = "srb2";
+  version = "2.2.8";
+
+  src = fetchFromGitHub {
+    owner = "STJr";
+    repo = "SRB2";
+    rev = "SRB2_release_${version}";
+    sha256 = "10prk617pbxkpiyybwwjzv425pkjczfqdb8pxwfyq91aa2rg0kl8";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    nasm
+    p7zip
+  ];
+
+  buildInputs = [
+    curl
+    libgme
+    libpng
+    openmpt123
+    SDL2
+    SDL2_mixer
+    zlib
+  ];
+
+  cmakeFlags = [
+    "-DSRB2_ASSET_DIRECTORY=/build/source/assets"
+    "-DGME_INCLUDE_DIR=${libgme}/include"
+    "-DOPENMPT_INCLUDE_DIR=${openmpt123}/include"
+    "-DSDL2_MIXER_INCLUDE_DIR=${SDL2_mixer}/include/SDL2"
+    "-DSDL2_INCLUDE_DIR=${SDL2.dev}/include/SDL2"
+  ];
+
+  patches = [
+    ./wadlocation.patch
+  ];
+
+  prePatchPhase = ''sed "s#@wadlocation@#$out#" ${./wadlocation.patch} | patch -p1'';
+
+  preConfigure = ''
+    7z x ${assets} -o"/build/source/assets" -aos
+    7z x ${assets_optional} -o"/build/source/assets" -aos
+  '';
+
+  postInstall = ''
+    mkdir $out/bin
+    mv $out/lsdlsrb2-${version} $out/bin/srb2
+  '';
+
+  meta = with lib; {
+    description = "Sonic Robo Blast 2 is a 3D Sonic the Hedgehog fangame based on a modified version of Doom Legacy";
+    homepage = "https://www.srb2.org/";
+    platforms = platforms.linux;
+    license = licenses.gpl2plus;
+    maintainers = with maintainers; [ zeratax ];
+  };
+}

--- a/pkgs/games/srb2/wadlocation.patch
+++ b/pkgs/games/srb2/wadlocation.patch
@@ -1,0 +1,72 @@
+diff --git a/src/sdl/i_system.c b/src/sdl/i_system.c
+index 10c0747bf..861f00728 100644
+--- a/src/sdl/i_system.c
++++ b/src/sdl/i_system.c
+@@ -145,13 +145,7 @@ int TimeFunction(int requested_frequency);
+ 
+ // Locations for searching the srb2.pk3
+ #if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)
+-#define DEFAULTWADLOCATION1 "/usr/local/share/games/SRB2"
+-#define DEFAULTWADLOCATION2 "/usr/local/games/SRB2"
+-#define DEFAULTWADLOCATION3 "/usr/share/games/SRB2"
+-#define DEFAULTWADLOCATION4 "/usr/games/SRB2"
+-#define DEFAULTSEARCHPATH1 "/usr/local/games"
+-#define DEFAULTSEARCHPATH2 "/usr/games"
+-#define DEFAULTSEARCHPATH3 "/usr/local"
++#define DEFAULTWADLOCATION1 "@wadlocation@"
+ #elif defined (_WIN32)
+ #define DEFAULTWADLOCATION1 "c:\\games\\srb2"
+ #define DEFAULTWADLOCATION2 "\\games\\srb2"
+@@ -2812,34 +2806,6 @@ static const char *locateWad(void)
+ 	if (((envstr = I_GetEnv("SRB2WADDIR")) != NULL) && isWadPathOk(envstr))
+ 		return envstr;
+ 
+-#ifndef NOCWD
+-	I_OutputMsg(",.");
+-	// examine current dir
+-	strcpy(returnWadPath, ".");
+-	if (isWadPathOk(returnWadPath))
+-		return NULL;
+-#endif
+-
+-
+-#ifdef CMAKECONFIG
+-#ifndef NDEBUG
+-	I_OutputMsg(","CMAKE_ASSETS_DIR);
+-	strcpy(returnWadPath, CMAKE_ASSETS_DIR);
+-	if (isWadPathOk(returnWadPath))
+-	{
+-		return returnWadPath;
+-	}
+-#endif
+-#endif
+-
+-#ifdef __APPLE__
+-	OSX_GetResourcesPath(returnWadPath);
+-	I_OutputMsg(",%s", returnWadPath);
+-	if (isWadPathOk(returnWadPath))
+-	{
+-		return returnWadPath;
+-	}
+-#endif
+ 
+ 	// examine default dirs
+ #ifdef DEFAULTWADLOCATION1
+@@ -2884,16 +2850,7 @@ static const char *locateWad(void)
+ 	if (isWadPathOk(returnWadPath))
+ 		return returnWadPath;
+ #endif
+-#ifndef NOHOME
+-	// find in $HOME
+-	I_OutputMsg(",HOME");
+-	if ((envstr = I_GetEnv("HOME")) != NULL)
+-	{
+-		WadPath = searchWad(envstr);
+-		if (WadPath)
+-			return WadPath;
+-	}
+-#endif
++
+ #ifdef DEFAULTSEARCHPATH1
+ 	// find in /usr/local
+ 	I_OutputMsg(", in:"DEFAULTSEARCHPATH1);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25854,6 +25854,8 @@ in
 
   springLobby = callPackage ../games/spring/springlobby.nix { };
 
+  srb2 = callPackage ../games/srb2 { };
+
   ssl-cert-check = callPackage ../tools/admin/ssl-cert-check { };
 
   stardust = callPackage ../games/stardust {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
